### PR TITLE
Add delete option to UI

### DIFF
--- a/pkg/http/api/delete.go
+++ b/pkg/http/api/delete.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
+)
+
+type deleteHandler struct {
+	Storage storage.StorageProvider
+}
+
+func newDeleteHandler(store storage.StorageProvider) http.Handler {
+	return auth.AuthHandler(&deleteHandler{Storage: store})
+}
+
+func (h *deleteHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	files, ok := r.Form["file"]
+	if !ok {
+		http.Error(w, "Invalid parameters", http.StatusBadRequest)
+		return
+	}
+
+	dir := ""
+	for _, file := range files {
+		if dir == "" {
+			index := strings.LastIndex(file, "/")
+			if index > 0 {
+				dir = file[:index]
+			}
+		}
+
+		err = h.Storage.Delete(r.Context(), user, file)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/?dir=%s", dir), http.StatusTemporaryRedirect)
+}

--- a/pkg/http/api/init.go
+++ b/pkg/http/api/init.go
@@ -13,4 +13,5 @@ func Init(mux *http.ServeMux, db *gorm.DB, storage storage.StorageProvider, file
 	mux.Handle("/api/download", newDownloadHandler(db, storage))
 	mux.Handle("/api/list", newListHandler(storage))
 	mux.Handle("/api/fileinfo", newFileInfoHandler(storage, fileinfo))
+	mux.Handle("/api/mkdir", newMkdirHandler(storage))
 }

--- a/pkg/http/api/init.go
+++ b/pkg/http/api/init.go
@@ -14,4 +14,5 @@ func Init(mux *http.ServeMux, db *gorm.DB, storage storage.StorageProvider, file
 	mux.Handle("/api/list", newListHandler(storage))
 	mux.Handle("/api/fileinfo", newFileInfoHandler(storage, fileinfo))
 	mux.Handle("/api/mkdir", newMkdirHandler(storage))
+	mux.Handle("/api/delete", newDeleteHandler(storage))
 }

--- a/pkg/http/api/list.go
+++ b/pkg/http/api/list.go
@@ -20,7 +20,12 @@ func newListHandler(store storage.StorageProvider) http.Handler {
 }
 
 func (h *listHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
-	files, err := h.Storage.ListDirectory(r.Context(), user, "/")
+	dir := r.URL.Query().Get("dir")
+	if dir == "" {
+		dir = "/"
+	}
+
+	files, err := h.Storage.ListDirectory(r.Context(), user, dir)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/http/api/mkdir.go
+++ b/pkg/http/api/mkdir.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
+)
+
+type mkdirHandler struct {
+	Storage storage.StorageProvider
+}
+
+func newMkdirHandler(store storage.StorageProvider) http.Handler {
+	return auth.AuthHandler(&mkdirHandler{Storage: store})
+}
+
+func (h *mkdirHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	path := r.Form.Get("path")
+	foldername := r.Form.Get("foldername")
+	if path == "" || foldername == "" {
+		http.Error(w, "Invalid parameters", http.StatusBadRequest)
+		return
+	}
+
+	dir := filepath.Join(path, foldername)
+
+	err = h.Storage.Mkdir(r.Context(), user, dir)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/?dir=%s", dir), http.StatusTemporaryRedirect)
+}

--- a/pkg/http/api/upload.go
+++ b/pkg/http/api/upload.go
@@ -46,6 +46,11 @@ func newUploadHandler(db *gorm.DB, store storage.StorageProvider) http.Handler {
 }
 
 func (h *uploadHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
+	dir := r.URL.Query().Get("dir")
+	if dir == "" {
+		dir = "/"
+	}
+
 	if r.Method == http.MethodOptions {
 		w.Header().Add("Tus-Extension", "creation")
 		w.Header().Add("Tus-Resumable", "1.0.0")
@@ -101,7 +106,7 @@ func (h *uploadHandler) Serve(user *models.User, w http.ResponseWriter, r *http.
 			Length: length,
 		}
 
-		file, err := h.Storage.File(r.Context(), user, path.Join("/", filename))
+		file, err := h.Storage.File(r.Context(), user, path.Join(dir, filename))
 		if err != nil {
 			logrus.Error(err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/http/assets/folder.gohtml
+++ b/pkg/http/assets/folder.gohtml
@@ -3,10 +3,15 @@
 <head>
   <link href="/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
   <link href="/css/dataTables.bootstrap5.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="/css/select.dataTables.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="/css/buttons.bootstrap5.min.css" rel="stylesheet" crossorigin="anonymous">
   <script src="/js/lib/jquery.min.js"></script>
   <script src="/js/lib/jquery.dataTables.min.js"></script>
   <script src="/js/lib/bootstrap.bundle.min.js"></script>
   <script src="/js/lib/dataTables.bootstrap5.min.js"></script>
+  <script src="/js/lib/dataTables.select.min.js"></script>
+  <script src="/js/lib/dataTables.buttons.min.js"></script>
+  <script src="/js/lib/buttons.bootstrap5.min.js"></script>
   <script src="/js/lib/tus.min.js"></script>
 
   {{ navbar .Navbar }}
@@ -61,6 +66,27 @@
             </form>
           </div>
         </div>
+      </div>
+    </div>
+
+    <div class="modal fade" id="confirmFileDeletionModal" tabIndex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-scrollable">
+        <form action="/api/delete" method="POST">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Confirm file deletion</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+
+            <div class="modal-body">
+            </div>
+
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+              <button type="submit" class="btn btn-primary">Confirm</button>
+            </div>
+          </div>
+        </form>
       </div>
     </div>
 

--- a/pkg/http/assets/folder.gohtml
+++ b/pkg/http/assets/folder.gohtml
@@ -16,28 +16,96 @@
 
 <body class="text-center">
   <div class="container">
-    <form enctype="multipart/form-data" action="/api/upload" method="POST">
-      <div class="file-upload-wrapper input-group">
-        <input type="file" id="input-file-now-custom-2" name="file" class="file-upload form-control-sm" multiple/>
-        <button class="btn btn-primary" id="uploadButton">Upload</button>
+
+    <div class="modal fade" id="uploadFileModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Upload File</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <form enctype="multipart/form-data" action="/api/upload" method="POST">
+              <div class="file-upload-wrapper input-group">
+                <input type="file" id="input-file-now-custom-2" name="file" class="file-upload form-control" multiple/>
+                <button class="btn btn-primary" id="uploadButton">Upload</button>
+              </div>
+            </form>
+          </div>
+        </div>
       </div>
-      <div class="progress" style="visibility:hidden">
-        <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
+    </div>
+
+    <div class="modal fade" id="newFolderModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">New Folder</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <form action="/api/mkdir" method="POST">
+
+              {{ $fullpath := "" }}
+              {{ range $folder := .Dir }}
+                {{ if ne $folder "" }}
+                  {{ $fullpath = printf "%s/%s" $fullpath $folder }}
+                {{ end }}
+              {{ end }}
+              <input type="hidden" name="path" value="{{ $fullpath }}"/>
+
+              <div class="input-group">
+                <input type="text" placeholder="New Folder Name" name="foldername" class="form-control"/>
+                <button class="btn btn-primary" type="submit">Create</button>
+              </div>
+            </form>
+          </div>
+        </div>
       </div>
-    </form>
+    </div>
 
     <div id="liveAlertPlaceholder"></div>
 
+    <div class="progress" style="visibility:hidden">
+      <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
+    </div>
+
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item active"><a href="/?dir=/">Home</a></li>
-        {{ $fulldir := "" }}
-        {{ range $folder := .Dir }}
-          {{ if ne $folder "" }}
-            {{ $fulldir = printf "%s/%s" $fulldir $folder }}
-            <li class="breadcrumb-item active"><a href="/?dir={{ $fulldir }}">{{ $folder }}</a></li>
+
+        {{ $size := len .Dir }}
+        {{ if eq $size 0 }}
+          <li class="breadcrumb-item active">Home</li>
+        {{ else }}
+          <li class="breadcrumb-item"><a href="/?dir=/">Home</a></li>
+
+          {{ $active := index .Dir (add $size -1) }}
+          {{ $fullpath := "" }}
+          {{ range $index, $folder := .Dir }}
+            {{ $fullpath = printf "%s/%s" $fullpath $folder }}
+            {{ if eq $folder $active }}
+              <li class="breadcrumb-item active">{{ $folder }}</a></li>
+            {{ else }}
+              <li class="breadcrumb-item"><a href="/?dir={{ $fullpath }}">{{ $folder }}</a></li>
+            {{ end }}
           {{ end }}
+
         {{ end }}
+
+        <li class="breadcrumb-item dropdown">
+            <a class="dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+              Add
+            </a>
+            <ul class="dropdown-menu">
+              <li>
+                <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#uploadFileModal">Upload File</a>
+              </li>
+
+              <li>
+                <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#newFolderModal">New Folder</a>
+              </li>
+            </ul>
+        </li>
       </ol>
     </nav>
 

--- a/pkg/http/assets/folder.gohtml
+++ b/pkg/http/assets/folder.gohtml
@@ -28,6 +28,19 @@
 
     <div id="liveAlertPlaceholder"></div>
 
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item active"><a href="/?dir=/">Home</a></li>
+        {{ $fulldir := "" }}
+        {{ range $folder := .Dir }}
+          {{ if ne $folder "" }}
+            {{ $fulldir = printf "%s/%s" $fulldir $folder }}
+            <li class="breadcrumb-item active"><a href="/?dir={{ $fulldir }}">{{ $folder }}</a></li>
+          {{ end }}
+        {{ end }}
+      </ol>
+    </nav>
+
     <div class="table">
       <table class="table table-striped" style="width:100%" id="directory">
         <thead>

--- a/pkg/http/assets/includes/navbar.gohtml
+++ b/pkg/http/assets/includes/navbar.gohtml
@@ -1,6 +1,8 @@
+<title>Leicht-Cloud</title>
+
 <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-dark mb-2">
   <div class="container-fluid">
-    <a class="navbar-brand" href="/">Go-Cloud</a>
+    <a class="navbar-brand" href="/">Leicht-Cloud</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/pkg/http/assets/js/folder.js
+++ b/pkg/http/assets/js/folder.js
@@ -61,11 +61,27 @@ function fileInfo(file) {
 };
 
 $(document).ready(function () {
+    var params = new URLSearchParams(window.location.search);
+    var dir = "/";
+    if (params.has("dir")) {
+        dir = params.get("dir");
+    }
+    if (dir.slice(-1) != "/") {
+        dir += "/";
+    }
+
     var datatable = $('#directory').DataTable({
         "columnDefs": [{
                 "render": function (data, type, row) {
-                    console.log(data);
-                    return '<a href="#" onclick="fileInfo(\'' + data + '\');">' + data + '</a>';
+                    if (data[1]) {
+                        // https://icons.getbootstrap.com/icons/folder/
+                        return '<a href="/?dir=' + dir + data[0] + '">'
+                        + '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-folder" viewBox="0 0 16 16"><path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31zM2.19 4a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91h10.348a1 1 0 0 0 .995-.91l.637-7A1 1 0 0 0 13.81 4H2.19zm4.69-1.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707z"/></svg> '
+                        + data[0] + '</a>';
+                    }
+                    return '<a href="#" onclick="fileInfo(\'' + data[0] + '\');">'
+                        + '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark" viewBox="0 0 16 16"><path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h-2z"/></svg> '
+                        + data[0] + '</a>';
                 },
                 "targets": 0 // name
             },
@@ -84,19 +100,23 @@ $(document).ready(function () {
         ]
     });
 
-    $.get("/api/list")
+    $.get("/api/list?dir=" + dir)
         .fail(function (xhr, status, error) {
             alert(xhr.responseText, 'danger');
         })
         .done(function (data) {
             data = data.split('\n');
             data.forEach(function (data) {
-                json = JSON.parse(data);
-                datatable.row.add([
-                    json.name,
-                    json.created_at,
-                    json.size
-                ]).draw(false);
+                try {
+                    json = JSON.parse(data);
+                    datatable.row.add([
+                        [json.name, json.directory],
+                        json.created_at,
+                        json.size
+                    ]).draw(false);
+                } catch (e) {
+                    console.log(e);
+                }
             });
 
             datatable.draw();
@@ -155,7 +175,7 @@ $(document).ready(function () {
         toggleBtn.textContent = 'pause upload'
 
         var options = {
-            endpoint: "/api/upload",
+            endpoint: "/api/upload?dir=" + dir,
             chunkSize: 1024 * 1024 * 32,
             retryDelays: [0, 1000, 3000, 5000],
             parallelUploads: 1,

--- a/pkg/http/root.go
+++ b/pkg/http/root.go
@@ -41,11 +41,19 @@ func (h *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		dir = "/"
 	}
 
+	dirSplit := []string{}
+
+	for _, str := range strings.Split(dir, "/") {
+		if str != "" {
+			dirSplit = append(dirSplit, str)
+		}
+	}
+
 	ctx := template.AttachTemplateData(r.Context(), folderTemplateData{
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
-		Dir: strings.Split(dir, "/"),
+		Dir: dirSplit,
 	})
 
 	h.StaticHandler.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/http/root.go
+++ b/pkg/http/root.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
 	"github.com/leicht-cloud/leicht-cloud/pkg/http/template"
@@ -15,6 +16,7 @@ type rootHandler struct {
 
 type folderTemplateData struct {
 	Navbar template.NavbarData
+	Dir    []string
 }
 
 func (h *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -34,10 +36,16 @@ func (h *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// internal rewrite to the root folder
 	r.URL.Path = "/folder.gohtml"
 
+	dir := r.URL.Query().Get("dir")
+	if dir == "" {
+		dir = "/"
+	}
+
 	ctx := template.AttachTemplateData(r.Context(), folderTemplateData{
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
+		Dir: strings.Split(dir, "/"),
 	})
 
 	h.StaticHandler.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/http/template/handler.go
+++ b/pkg/http/template/handler.go
@@ -30,6 +30,7 @@ func createFuncMap(assets fs.FS) (out template.FuncMap, err error) {
 	return template.FuncMap{
 		"navbar":      tmplFunc(assets, "includes/navbar.gohtml"),
 		"adminnavbar": tmplFunc(assets, "includes/navbar.admin.gohtml"),
+		"add":         func(a, b int) int { return a + b },
 		"notnil": func(data interface{}) bool {
 			return data != nil
 		},

--- a/update-assets.sh
+++ b/update-assets.sh
@@ -10,14 +10,24 @@
 mkdir -p assets/js/lib assets/css
 
 JQUERY_URL="https://code.jquery.com/jquery-3.6.0.min.js"
-DATATABLES_URL="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"
-DATATABLES_BOOTSTRAP_JS_URL="https://cdn.datatables.net/1.11.3/js/dataTables.bootstrap5.min.js"
-DATATABLES_BOOTSTRAP_CSS_URL="https://cdn.datatables.net/1.11.3/css/dataTables.bootstrap5.min.css"
+DATATABLES_URL="https://cdn.datatables.net/1.11.4/js/jquery.dataTables.min.js"
+DATATABLES_BOOTSTRAP_JS_URL="https://cdn.datatables.net/1.11.4/js/dataTables.bootstrap5.min.js"
+DATATABLES_BOOTSTRAP_CSS_URL="https://cdn.datatables.net/1.11.4/css/dataTables.bootstrap5.min.css"
+DATATABLES_SELECT_CSS_URL="https://cdn.datatables.net/select/1.3.4/css/select.dataTables.min.css"
+DATATABLES_SELECT_JS_URL="https://cdn.datatables.net/select/1.3.4/js/dataTables.select.min.js"
+DATATABLES_BUTTONS_JS_URL="https://cdn.datatables.net/buttons/2.2.2/js/dataTables.buttons.min.js"
+DATATABLES_BUTTONS_BOOTSTRAP_JS_URL="https://cdn.datatables.net/buttons/2.2.2/js/buttons.bootstrap5.min.js"
+DATATABLES_BUTTONS_CSS_URL="https://cdn.datatables.net/buttons/2.2.2/css/buttons.bootstrap5.min.css"
 
 wget -O assets/js/lib/jquery.min.js $JQUERY_URL
 wget -O assets/js/lib/jquery.dataTables.min.js $DATATABLES_URL
 wget -O assets/js/lib/dataTables.bootstrap5.min.js $DATATABLES_BOOTSTRAP_JS_URL
 wget -O assets/css/dataTables.bootstrap5.min.css $DATATABLES_BOOTSTRAP_CSS_URL
+wget -O assets/js/lib/dataTables.select.min.js $DATATABLES_SELECT_JS_URL
+wget -O assets/css/select.dataTables.min.css $DATATABLES_SELECT_CSS_URL
+wget -O assets/js/lib/dataTables.buttons.min.js $DATATABLES_BUTTONS_JS_URL
+wget -O assets/js/lib/buttons.bootstrap5.min.js $DATATABLES_BUTTONS_BOOTSTRAP_JS_URL
+wget -O assets/css/buttons.bootstrap5.min.css $DATATABLES_BUTTONS_CSS_URL
 
 BOOTSTRAP_CSS_URL="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
 BOOTSTRAP_JS_URL="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"


### PR DESCRIPTION
This branch was supposed to contain more UI changes, but in the end I only ended up implementing deleting of files. This does however mean that the folder UI is pretty much usable by now. The only thing that is basically missing is file moving and copying. I however will implement this at a later date. As I realize that for the storage interface (and plugins in particular) it would make a lot more sense to add a copy method. Meaning that a copy operation doesn't have all the data go through the main process or even the main machine in case the storage is running elsewhere (like with s3), meaning it could be quite a bit faster.