### PR TITLE
Initial app support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pkg/http/assets/js/lib/
 # binaries
 /leicht-cloud
 /build-plugin
+/run-app
 
 # files to help with testing
 *.db

--- a/cmd/build-plugin/main.go
+++ b/cmd/build-plugin/main.go
@@ -51,11 +51,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	fout, err := os.OpenFile(filepath.Join(*outdir, fmt.Sprintf("%s.plugin", manifest.Name)), os.O_CREATE|os.O_WRONLY, 0600)
+	fout, err := os.CreateTemp(*outdir, fmt.Sprintf("%s.plugin.*", manifest.Name))
 	if err != nil {
 		logrus.Fatal(err)
 	}
 	defer fout.Close()
+	defer func(src string) {
+		err := os.Rename(src, filepath.Join(*outdir, fmt.Sprintf("%s.plugin", manifest.Name)))
+		if err != nil {
+			logrus.Error(err)
+		}
+	}(fout.Name())
 
 	gw, err := gzip.NewWriterLevel(fout, gzip.BestCompression)
 	if err != nil {

--- a/cmd/build-plugin/main.go
+++ b/cmd/build-plugin/main.go
@@ -37,17 +37,18 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	validTypes := []string{"fileinfo", "storage", "app"}
-	found := false
-
-	for _, typ := range validTypes {
-		if manifest.Type == typ {
-			found = true
+	warnings := manifest.Warnings()
+	fatal := false
+	for warning := range warnings {
+		if warning.Fatal {
+			logrus.Errorf("%s", warning)
+			fatal = true
+		} else {
+			logrus.Warnf("%s", warning)
 		}
 	}
-
-	if !found {
-		logrus.Fatalf("Invalid type: %s", manifest.Type)
+	if fatal {
+		os.Exit(1)
 	}
 
 	fout, err := os.OpenFile(filepath.Join(*outdir, fmt.Sprintf("%s.plugin", manifest.Name)), os.O_CREATE|os.O_WRONLY, 0600)

--- a/cmd/build-plugin/main.go
+++ b/cmd/build-plugin/main.go
@@ -37,7 +37,7 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	validTypes := []string{"fileinfo", "storage"}
+	validTypes := []string{"fileinfo", "storage", "app"}
 	found := false
 
 	for _, typ := range validTypes {

--- a/cmd/build-plugin/main.go
+++ b/cmd/build-plugin/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 	path := flag.Arg(0)
 
-	manifest, err := plugin.ParseManifestFromFile(path, "")
+	manifest, err := plugin.ParseManifestFromFile(path)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/leicht-cloud/config.go
+++ b/cmd/leicht-cloud/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/leicht-cloud/leicht-cloud/pkg/app"
 	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
 	"github.com/leicht-cloud/leicht-cloud/pkg/fileinfo"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
@@ -19,6 +20,7 @@ type Config struct {
 	Storage    storage.Config    `yaml:"storage"`
 	Plugin     plugin.Config     `yaml:"plugin"`
 	FileInfo   fileinfo.Config   `yaml:"fileinfo"`
+	Apps       app.Config        `yaml:"apps"`
 	Auth       auth.Config       `yaml:"auth"`
 	Prometheus prometheus.Config `yaml:"prometheus"`
 }

--- a/cmd/leicht-cloud/main.go
+++ b/cmd/leicht-cloud/main.go
@@ -80,6 +80,7 @@ func main() {
 	if err != nil {
 		logrus.Fatal(err)
 	}
+	defer apps.Close()
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)

--- a/cmd/leicht-cloud/main.go
+++ b/cmd/leicht-cloud/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	logrus.Infof("Initializing apps")
-	apps, err := config.Apps.CreateProvider(pluginManager, prom)
+	apps, err := config.Apps.CreateProvider(pluginManager, storage, prom)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/leicht-cloud/main.go
+++ b/cmd/leicht-cloud/main.go
@@ -75,11 +75,17 @@ func main() {
 		logrus.Fatal(err)
 	}
 
+	logrus.Infof("Initializing apps")
+	apps, err := config.Apps.CreateProvider(pluginManager, prom)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 
 	logrus.Info("Initialing http server")
-	server, err := gchttp.InitHttpServer(db, auth, storage, pluginManager, fileinfo)
+	server, err := gchttp.InitHttpServer(db, auth, storage, pluginManager, apps, fileinfo)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/run-app/main.go
+++ b/cmd/run-app/main.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/app"
+	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
+	lchttp "github.com/leicht-cloud/leicht-cloud/pkg/http"
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage/builtin/local"
+	"github.com/sirupsen/logrus"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var dummyUser = &models.User{
+	ID:    1,
+	Email: "test@test.com",
+}
+
+func main() {
+	logrus.SetReportCaller(true)
+	runtime := flag.String("runtime", "namespace", "The kind of runtime to use for the app")
+
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		logrus.Fatalf("Requires 1 argument, got %d", len(flag.Args()))
+	}
+	path := flag.Arg(0)
+	appname := strings.TrimSuffix(filepath.Base(path), ".plugin")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "leicht-cloud-*")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Infof("Setting up tmp directory: %s", tmpdir)
+	defer os.RemoveAll(tmpdir)
+
+	err = os.Mkdir(filepath.Join(tmpdir, "data"), 0700)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	_, authProvider, err := setupAuthProvider(filepath.Join(tmpdir, "test.db"))
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	store := local.NewStorageProvider(path)
+
+	config := plugin.Config{
+		Debug:   true,
+		Path:    []string{filepath.Dir(path)},
+		WorkDir: tmpdir,
+		Runner:  *runtime,
+	}
+
+	pluginManager, err := config.CreateManager(nil)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	appManager, err := app.NewManager(pluginManager, store, nil, appname)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	appInstance, err := appManager.GetApp(appname)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	plugin := appInstance.GetPlugin()
+
+	mux := http.NewServeMux()
+	mux.Handle("/apps/embed/", auth.AuthHandler(appManager))
+	assets, err := lchttp.InitStatic()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	mux.Handle("/", &rootHandler{
+		Auth:          authProvider,
+		StaticHandler: http.FileServer(http.FS(assets)),
+		appname:       appname,
+		permissions:   appInstance.IFramePermissions(),
+	})
+
+	httpServer := http.Server{
+		Handler: auth.AuthMiddleware(authProvider, mux),
+		Addr:    "127.0.0.1:8080",
+	}
+
+	go func() {
+		err := httpServer.ListenAndServe()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
+	logrus.Info("Switching to plugin stdout")
+	stdout := plugin.Stdout()
+	defer stdout.Close()
+	go io.Copy(os.Stdout, stdout) // nolint:errcheck
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	<-c
+	logrus.Info("Closing server")
+
+	httpServer.Close()
+}
+
+func setupAuthProvider(path string) (*gorm.DB, *auth.Provider, error) {
+	db, err := gorm.Open(sqlite.Open(path))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = models.InitModels(db)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// we create a temporary key ourselves, rather than let the regular application library do this
+	// as the regular application library will print a warning telling the user to add it to their config
+	// which makes very little sense for this application.
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	config := &auth.Config{
+		PrivateKey: string(privateKey),
+	}
+
+	provider, err := config.Create(db)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = db.Begin().Create(&dummyUser).Commit().Error
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return db, provider, nil
+}
+
+type rootHandler struct {
+	Auth          *auth.Provider
+	StaticHandler http.Handler
+
+	appname     string
+	permissions string
+}
+
+func (h *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if auth.GetUserFromRequest(r) == nil {
+		token, err := h.Auth.Authenticate(dummyUser)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:   "auth",
+			Value:  token,
+			MaxAge: 86400,
+		})
+	}
+
+	if r.URL.Path != "/" {
+		h.StaticHandler.ServeHTTP(w, r)
+		return
+	}
+
+	fmt.Fprintf(w, `<html>
+
+	<head>
+		<link href="/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+		<script src="/js/lib/bootstrap.bundle.min.js"></script>
+		<script src="/js/lib/jquery.min.js"></script>
+	</head>
+	
+	<body>
+		<div style="height:90%%" class="container wrapper">
+			<iframe src="/apps/embed/%s/" height="100%%" width="100%%" sandbox="allow-same-origin %s">
+			</iframe>
+		</div>
+	</body>
+	
+	</html>`, h.appname, h.permissions)
+}

--- a/cmd/run-app/main.go
+++ b/cmd/run-app/main.go
@@ -192,7 +192,7 @@ func (h *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	
 	<body>
 		<div style="height:90%%" class="container wrapper">
-			<iframe src="/apps/embed/%s/" height="100%%" width="100%%" sandbox="allow-same-origin %s">
+			<iframe src="/apps/embed/%s/" height="100%%" width="100%%" sandbox="%s">
 			</iframe>
 		</div>
 	</body>

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/leicht-cloud/leicht-cloud/pkg/models"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
@@ -34,4 +35,15 @@ func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path strin
 	_, err = io.Copy(w, resp.Body)
 
 	return err
+}
+
+func (a *App) IFramePermissions() string {
+	manifest := a.plugin.Manifest()
+	out := ""
+
+	if manifest.Permissions.App.Javascript {
+		out += "allow-scripts "
+	}
+
+	return strings.Trim(out, " ")
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/golang-jwt/jwt"
+	"github.com/leicht-cloud/leicht-cloud/pkg/fileinfo/types"
 	"github.com/leicht-cloud/leicht-cloud/pkg/models"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
 	"go.uber.org/multierr"
@@ -98,4 +100,18 @@ func (a *App) IFramePermissions() string {
 	}
 
 	return strings.Trim(out, " ")
+}
+
+var ErrNoMatch = errors.New("No match")
+
+func (a *App) Opener(mime types.MimeType) (string, error) {
+	openers := a.plugin.Manifest().Permissions.App.FileOpener
+
+	for pattern, path := range openers {
+		if mime.Match(pattern) {
+			return path, nil
+		}
+	}
+
+	return "", ErrNoMatch
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -45,7 +45,7 @@ func (a *App) Close() error {
 		err = multierr.Append(err, closer.Close())
 	}
 
-	return err
+	return multierr.Combine(err, a.plugin.Close())
 }
 
 func (a *App) GetPlugin() plugin.PluginInterface {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -57,8 +57,13 @@ type UserClaims struct {
 	models.User
 }
 
-func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path string, body io.Reader) error {
-	uri, err := url.Parse(fmt.Sprintf("http://127.0.0.1/%s", strings.TrimPrefix(path, "/")))
+func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path string, query url.Values, headers http.Header, body io.Reader) error {
+	rawUri := fmt.Sprintf("http://127.0.0.1/%s", strings.TrimPrefix(path, "/"))
+	if len(query) > 0 {
+		rawUri = fmt.Sprintf("%s?%s", rawUri, query.Encode())
+	}
+
+	uri, err := url.Parse(rawUri)
 	if err != nil {
 		return err
 	}
@@ -67,6 +72,8 @@ func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path strin
 	if err != nil {
 		return err
 	}
+
+	req.Header = headers
 
 	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, UserClaims{
 		User: *user,

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -14,13 +14,13 @@ type App struct {
 	plugin plugin.PluginInterface
 }
 
-func (a *App) Serve(user *models.User, w http.ResponseWriter, path string) error {
+func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path string, body io.Reader) error {
 	uri, err := url.Parse(fmt.Sprintf("http://127.0.0.1/%s", path))
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("GET", uri.String(), nil)
+	req, err := http.NewRequest(method, uri.String(), body)
 	if err != nil {
 		return err
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -46,6 +46,10 @@ func (a *App) Close() error {
 	return err
 }
 
+func (a *App) GetPlugin() plugin.PluginInterface {
+	return a.plugin
+}
+
 type UserClaims struct {
 	jwt.StandardClaims
 	models.User

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -106,6 +106,10 @@ func (a *App) IFramePermissions() string {
 		out += "allow-scripts "
 	}
 
+	if manifest.Permissions.App.Forms {
+		out += "allow-forms "
+	}
+
 	return strings.Trim(out, " ")
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
+)
+
+type App struct {
+	plugin plugin.PluginInterface
+}
+
+func (a *App) Serve(user *models.User, w http.ResponseWriter, path string) error {
+	uri, err := url.Parse(fmt.Sprintf("http://127.0.0.1/%s", path))
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("GET", uri.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.plugin.HttpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(w, resp.Body)
+
+	return err
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,18 +1,41 @@
 package app
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/golang-jwt/jwt"
 	"github.com/leicht-cloud/leicht-cloud/pkg/models"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
 )
 
 type App struct {
 	plugin plugin.PluginInterface
+
+	jwtPrivateKey ed25519.PrivateKey
+	jwtPublicKey  ed25519.PublicKey
+}
+
+func newApp(plugin plugin.PluginInterface) (*App, error) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return &App{
+		plugin:        plugin,
+		jwtPrivateKey: privateKey,
+		jwtPublicKey:  publicKey,
+	}, nil
+}
+
+type UserClaims struct {
+	jwt.StandardClaims
+	models.User
 }
 
 func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path string, body io.Reader) error {
@@ -25,6 +48,18 @@ func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path strin
 	if err != nil {
 		return err
 	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, UserClaims{
+		User: *user,
+	})
+
+	// Sign and get the complete encoded token as a string using the secret
+	userToken, err := token.SignedString(a.jwtPrivateKey)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("X-Leicht-Cloud-User", userToken)
 
 	resp, err := a.plugin.HttpClient().Do(req)
 	if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -58,7 +58,7 @@ type UserClaims struct {
 }
 
 func (a *App) Serve(user *models.User, w http.ResponseWriter, method, path string, body io.Reader) error {
-	uri, err := url.Parse(fmt.Sprintf("http://127.0.0.1/%s", path))
+	uri, err := url.Parse(fmt.Sprintf("http://127.0.0.1/%s", strings.TrimPrefix(path, "/")))
 	if err != nil {
 		return err
 	}

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -3,12 +3,13 @@ package app
 import (
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
 	"github.com/leicht-cloud/leicht-cloud/pkg/prometheus"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
 )
 
 type Config struct {
 	Apps []string `yaml:"apps"`
 }
 
-func (c *Config) CreateProvider(pManager *plugin.Manager, prom *prometheus.Manager) (*Manager, error) {
-	return NewManager(pManager, prom, c.Apps...)
+func (c *Config) CreateProvider(pManager *plugin.Manager, store storage.StorageProvider, prom *prometheus.Manager) (*Manager, error) {
+	return NewManager(pManager, store, prom, c.Apps...)
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
+	"github.com/leicht-cloud/leicht-cloud/pkg/prometheus"
+)
+
+type Config struct {
+	Apps []string `yaml:"apps"`
+}
+
+func (c *Config) CreateProvider(pManager *plugin.Manager, prom *prometheus.Manager) (*Manager, error) {
+	return NewManager(pManager, prom, c.Apps...)
+}

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -49,7 +49,7 @@ func (m *Manager) Serve(user *models.User, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err := app.Serve(user, w, path)
+	err := app.Serve(user, w, r.Method, path, r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -36,7 +36,7 @@ func NewManager(pManager *plugin.Manager, prom *prometheus.Manager, apps ...stri
 }
 
 func (m *Manager) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
-	split := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/apps/"), "/", 2)
+	split := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/apps/embed/"), "/", 2)
 	appname := split[0]
 	path := "/"
 	if len(split) == 2 {

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/leicht-cloud/leicht-cloud/pkg/fileinfo/types"
 	"github.com/leicht-cloud/leicht-cloud/pkg/models"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
 	"github.com/leicht-cloud/leicht-cloud/pkg/prometheus"
@@ -134,6 +135,18 @@ func (m *Manager) Apps() []string {
 
 	for app := range m.apps {
 		out = append(out, app)
+	}
+
+	return out
+}
+
+func (m *Manager) Openers(mime types.MimeType) map[string]string {
+	out := make(map[string]string)
+	for name, app := range m.apps {
+		path, err := app.Opener(mime)
+		if err == nil {
+			out[name] = path
+		}
 	}
 
 	return out

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
+	"github.com/leicht-cloud/leicht-cloud/pkg/prometheus"
+)
+
+type Manager struct {
+	apps map[string]*App
+}
+
+func NewManager(pManager *plugin.Manager, prom *prometheus.Manager, apps ...string) (*Manager, error) {
+	out := &Manager{
+		apps: make(map[string]*App),
+	}
+
+	for _, name := range apps {
+		plugin, err := pManager.Start(name, "app")
+		if err != nil {
+			return nil, err
+		}
+
+		app := &App{
+			plugin: plugin,
+		}
+
+		out.apps[name] = app
+	}
+
+	return out, nil
+}
+
+func (m *Manager) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
+	split := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/apps/"), "/", 2)
+	appname := split[0]
+	path := "/"
+	if len(split) == 2 {
+		path = split[1]
+	}
+
+	app, ok := m.apps[appname]
+	if !ok {
+		http.Error(w, fmt.Sprintf("App not found: %s", appname), http.StatusNotFound)
+		return
+	}
+
+	err := app.Serve(user, w, path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -2,19 +2,26 @@ package app
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/leicht-cloud/leicht-cloud/pkg/models"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
 	"github.com/leicht-cloud/leicht-cloud/pkg/prometheus"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage/firewall"
+	storagePlugin "github.com/leicht-cloud/leicht-cloud/pkg/storage/plugin"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 )
 
 type Manager struct {
 	apps map[string]*App
 }
 
-func NewManager(pManager *plugin.Manager, prom *prometheus.Manager, apps ...string) (*Manager, error) {
+func NewManager(pManager *plugin.Manager, store storage.StorageProvider, prom *prometheus.Manager, apps ...string) (*Manager, error) {
 	out := &Manager{
 		apps: make(map[string]*App),
 	}
@@ -25,14 +32,58 @@ func NewManager(pManager *plugin.Manager, prom *prometheus.Manager, apps ...stri
 			return nil, err
 		}
 
-		app := &App{
-			plugin: plugin,
+		app, err := newApp(plugin)
+		if err != nil {
+			return nil, err
+		}
+
+		manifest := plugin.Manifest()
+		logrus.Debugf("manifest: %+v", manifest)
+
+		if manifest.Permissions.App.Storage.Enabled {
+			err = app.setupStorage(store, manifest.Permissions.App.Storage.ReadWrite, manifest.Permissions.App.Storage.WholeStore)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		out.apps[name] = app
 	}
 
 	return out, nil
+}
+
+func (a *App) setupStorage(store storage.StorageProvider, readwrite, wholestore bool) error {
+	socketPath := filepath.Join(a.plugin.WorkDir(), "storage.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return err
+	}
+
+	grpcServer := grpc.NewServer(
+		grpc.MaxRecvMsgSize(1024*1024*32),
+		grpc.WriteBufferSize(0),
+		grpc.ReadBufferSize(0),
+	)
+
+	if !readwrite { // if readwrite isn't toggled, we wrap into ReadOnly
+		store = storage.ReadOnly(store)
+	}
+	if !wholestore { // if we're not wholestore we will be restricted to a subfolder in /apps/<appname>
+		store = firewall.Firewall(store, fmt.Sprintf("/apps/%s", a.plugin.Manifest().Name))
+	}
+
+	storagePlugin.RegisterStorageProviderServer(grpcServer, storagePlugin.NewStorageBridge(store))
+
+	go func(listener net.Listener, grpcServer *grpc.Server) {
+		logrus.Infof("Starting storage listener on host on: %s", socketPath)
+		err := grpcServer.Serve(listener)
+		if err != nil {
+			logrus.Error(err)
+		}
+	}(listener, grpcServer)
+
+	return nil
 }
 
 func (m *Manager) GetApp(name string) (*App, error) {

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -38,7 +38,6 @@ func NewManager(pManager *plugin.Manager, store storage.StorageProvider, prom *p
 		}
 
 		manifest := plugin.Manifest()
-		logrus.Debugf("manifest: %+v", manifest)
 
 		if manifest.Permissions.App.Storage.Enabled {
 			err = app.setupStorage(store, manifest.Permissions.App.Storage.ReadWrite, manifest.Permissions.App.Storage.WholeStore)

--- a/pkg/app/manager.go
+++ b/pkg/app/manager.go
@@ -54,3 +54,13 @@ func (m *Manager) Serve(user *models.User, w http.ResponseWriter, r *http.Reques
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
+
+func (m *Manager) Apps() []string {
+	out := make([]string, 0)
+
+	for app := range m.apps {
+		out = append(out, app)
+	}
+
+	return out
+}

--- a/pkg/app/plugin/helpers.go
+++ b/pkg/app/plugin/helpers.go
@@ -1,0 +1,33 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/leicht-cloud/leicht-cloud/pkg/app"
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+)
+
+func (a *App) UnmarshalUserFromRequest(r *http.Request) (*models.User, error) {
+	raw := r.Header.Get("X-Leicht-Cloud-User")
+	if raw == "" {
+		return nil, fmt.Errorf("X-Leicht-Cloud-User header missing")
+	}
+
+	// TODO: We want to get rid of ParseUnverified once we have a decent way of passing data from the host
+	// to this container and we can pass along the jwt public key and can thus verify the user information.
+	// at which point we will also want to uncomment the token.Valid below and actually include it in the if statement
+	parser := jwt.Parser{}
+	token, _, err := parser.ParseUnverified(raw, &app.UserClaims{})
+	if err != nil {
+		return nil, err
+	}
+
+	if claims, ok := token.Claims.(*app.UserClaims); ok /* && token.Valid*/ {
+		return &claims.User, nil
+	} else {
+		return nil, errors.New("Invalid token")
+	}
+}

--- a/pkg/app/plugin/server.go
+++ b/pkg/app/plugin/server.go
@@ -1,0 +1,10 @@
+package plugin
+
+import (
+	"github.com/leicht-cloud/leicht-cloud/pkg/plugin/common"
+)
+
+// This is meant to be called in the main() of your plugin
+func Start() (err error) {
+	return common.Init(nil)
+}

--- a/pkg/app/plugin/server.go
+++ b/pkg/app/plugin/server.go
@@ -1,10 +1,68 @@
 package plugin
 
 import (
+	"context"
+	"net"
+	"time"
+
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin/common"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
+	storagePlugin "github.com/leicht-cloud/leicht-cloud/pkg/storage/plugin"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 )
 
+type App struct {
+	storageConn *grpc.ClientConn
+	storage     storage.StorageProvider
+}
+
+func Init() (*App, error) {
+	return &App{}, nil
+}
+
 // This is meant to be called in the main() of your plugin
-func Start() (err error) {
+func (a *App) Loop() error {
 	return common.Init(nil)
+}
+
+func (a *App) Close() error {
+	if a.storageConn != nil {
+		return a.storageConn.Close()
+	}
+	return nil
+}
+
+func (a *App) Storage() (storage.StorageProvider, error) {
+	if a.storage != nil {
+		return a.storage, nil
+	}
+
+	conn, err := grpc.Dial("storage.sock",
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+		grpc.WithReadBufferSize(0),
+		grpc.WithWriteBufferSize(0),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			logrus.Debugf("Connecting: %s", addr)
+			var dialer net.Dialer
+			dialer.Timeout = time.Second * 3
+			return dialer.DialContext(ctx, "unix", addr)
+		}),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	a.storageConn = conn
+
+	store, err := storagePlugin.NewGrpcStorage(conn, nil)
+	if err != nil {
+		return nil, err
+	}
+	a.storage = store
+
+	return store, nil
 }

--- a/pkg/fileinfo/manager.go
+++ b/pkg/fileinfo/manager.go
@@ -52,7 +52,7 @@ func NewManager(pManager *plugin.Manager, prom *prometheus.Manager, mimetypeProv
 
 			provider, err := fileinfoPlugin.NewGrpcFileinfo(conn)
 			if err != nil {
-				stdout := plugin.Stdout()
+				stdout := plugin.StdoutDump()
 				if len(stdout) > 0 {
 					logrus.Infof("-----STDOUT FOR PLUGIN: %s-----", name)
 					_, _ = io.Copy(os.Stdout, bytes.NewReader(stdout))

--- a/pkg/fileinfo/types/interface.go
+++ b/pkg/fileinfo/types/interface.go
@@ -73,15 +73,6 @@ type MimeTypeProvider interface {
 	MimeType(filename string, reader io.Reader) (*MimeType, error)
 }
 
-type MimeType struct {
-	Type    string `json:"type"`
-	SubType string `json:"subtype"`
-}
-
-func (m MimeType) String() string {
-	return fmt.Sprintf("%s/%s", m.Type, m.SubType)
-}
-
 type Result struct {
 	Name  string `json:"name"`
 	Data  []byte `json:"data"`

--- a/pkg/fileinfo/types/mime.go
+++ b/pkg/fileinfo/types/mime.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MimeType struct {
+	Type    string `json:"type"`
+	SubType string `json:"subtype"`
+}
+
+func ParseMime(in string) (MimeType, error) {
+	split := strings.SplitN(in, "/", 2)
+
+	return MimeType{
+		Type:    split[0],
+		SubType: split[1],
+	}, nil
+}
+
+func (m MimeType) String() string {
+	return fmt.Sprintf("%s/%s", m.Type, m.SubType)
+}
+
+func (m MimeType) Match(pattern string) bool {
+	parsed, err := ParseMime(pattern)
+	if err != nil {
+		return false
+	}
+	if parsed.Type != m.Type {
+		return false
+	}
+	if parsed.SubType == "*" {
+		return true
+	} else if parsed.SubType == m.SubType {
+		return true
+	}
+
+	return false
+}

--- a/pkg/fileinfo/types/mime.go
+++ b/pkg/fileinfo/types/mime.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+var ErrInvalidMime = errors.New("Invalid mime")
 
 type MimeType struct {
 	Type    string `json:"type"`
@@ -12,6 +15,10 @@ type MimeType struct {
 
 func ParseMime(in string) (MimeType, error) {
 	split := strings.SplitN(in, "/", 2)
+
+	if len(split) != 2 {
+		return MimeType{}, ErrInvalidMime
+	}
 
 	return MimeType{
 		Type:    split[0],

--- a/pkg/fileinfo/types/mime_test.go
+++ b/pkg/fileinfo/types/mime_test.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMime(t *testing.T) {
+	units := []struct {
+		in  string
+		out MimeType
+		err error
+	}{
+		{
+			in: "text/plain",
+			out: MimeType{
+				Type:    "text",
+				SubType: "plain",
+			},
+			err: nil,
+		},
+	}
+
+	for _, unit := range units {
+		t.Run(unit.in, func(t *testing.T) {
+			out, err := ParseMime(unit.in)
+			assert.Equal(t, unit.err, err)
+			if err == nil {
+				assert.Equal(t, unit.out.Type, out.Type)
+				assert.Equal(t, unit.out.SubType, out.SubType)
+			}
+		})
+	}
+}
+
+func TestMimeMatch(t *testing.T) {
+	units := []struct {
+		pattern string
+		mime    MimeType
+		output  bool
+	}{
+		{
+			pattern: "text/plain",
+			mime: MimeType{
+				Type:    "text",
+				SubType: "plain",
+			},
+			output: true,
+		},
+		{
+			pattern: "text/*",
+			mime: MimeType{
+				Type:    "text",
+				SubType: "plain",
+			},
+			output: true,
+		},
+		{
+			pattern: "image/*",
+			mime: MimeType{
+				Type:    "text",
+				SubType: "plain",
+			},
+			output: false,
+		},
+	}
+
+	for _, unit := range units {
+		t.Run(unit.pattern, func(t *testing.T) {
+			out := unit.mime.Match(unit.pattern)
+			assert.Equal(t, unit.output, out)
+		})
+	}
+}

--- a/pkg/fileinfo/types/mime_test.go
+++ b/pkg/fileinfo/types/mime_test.go
@@ -20,6 +20,10 @@ func TestParseMime(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			in:  "",
+			err: ErrInvalidMime,
+		},
 	}
 
 	for _, unit := range units {

--- a/pkg/http/admin/init.go
+++ b/pkg/http/admin/init.go
@@ -4,19 +4,14 @@ import (
 	"net/http"
 
 	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
-	"github.com/leicht-cloud/leicht-cloud/pkg/http/template"
 	"github.com/leicht-cloud/leicht-cloud/pkg/plugin"
 	"gorm.io/gorm"
 )
 
 func Init(mux *http.ServeMux, auth *auth.Provider, templateHandler http.Handler, pluginManager *plugin.Manager, db *gorm.DB) {
-	navbar := template.AdminNavbarData{
-		Plugins: pluginManager.Plugins(),
-	}
-
-	mux.Handle("/admin/", Middleware(auth, &rootHandler{StaticHandler: templateHandler, AdminNavbar: navbar}))
-	mux.Handle("/admin/userlist", Middleware(auth, &userlistHandler{StaticHandler: templateHandler, AdminNavbar: navbar, DB: db}))
-	mux.Handle("/admin/user", Middleware(auth, &userHandler{StaticHandler: templateHandler, AdminNavbar: navbar, DB: db}))
-	mux.Handle("/admin/plugin", Middleware(auth, &pluginHandler{AdminNavbar: navbar, StaticHandler: templateHandler}))
+	mux.Handle("/admin/", Middleware(auth, &rootHandler{StaticHandler: templateHandler}))
+	mux.Handle("/admin/userlist", Middleware(auth, &userlistHandler{StaticHandler: templateHandler, DB: db}))
+	mux.Handle("/admin/user", Middleware(auth, &userHandler{StaticHandler: templateHandler, DB: db}))
+	mux.Handle("/admin/plugin", Middleware(auth, &pluginHandler{StaticHandler: templateHandler}))
 	mux.Handle("/admin/plugin/stdout", Middleware(auth, &pluginStdoutHandler{PluginManager: pluginManager}))
 }

--- a/pkg/http/admin/plugin.go
+++ b/pkg/http/admin/plugin.go
@@ -11,7 +11,6 @@ import (
 )
 
 type pluginHandler struct {
-	AdminNavbar   template.AdminNavbarData
 	StaticHandler http.Handler
 }
 
@@ -20,12 +19,10 @@ func (h *pluginHandler) Serve(user *models.User, w http.ResponseWriter, r *http.
 	r.URL.Path = "/admin.pluginview.gohtml"
 
 	ctx := template.AttachTemplateData(r.Context(), struct {
-		Name        string
-		AdminNavbar template.AdminNavbarData
-		Navbar      template.NavbarData
+		Name   string
+		Navbar template.NavbarData
 	}{
-		Name:        r.URL.Query().Get("name"),
-		AdminNavbar: h.AdminNavbar,
+		Name: r.URL.Query().Get("name"),
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},

--- a/pkg/http/admin/root.go
+++ b/pkg/http/admin/root.go
@@ -10,13 +10,11 @@ import (
 
 type rootHandler struct {
 	StaticHandler http.Handler
-	AdminNavbar   template.AdminNavbarData
 	DB            *gorm.DB
 }
 
 type adminTemplateData struct {
-	Navbar      template.NavbarData
-	AdminNavbar template.AdminNavbarData
+	Navbar template.NavbarData
 }
 
 func (h *rootHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
@@ -27,7 +25,6 @@ func (h *rootHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Re
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
-		AdminNavbar: h.AdminNavbar,
 	}
 
 	ctx := template.AttachTemplateData(r.Context(), data)

--- a/pkg/http/admin/user.go
+++ b/pkg/http/admin/user.go
@@ -14,14 +14,12 @@ import (
 
 type userHandler struct {
 	StaticHandler http.Handler
-	AdminNavbar   template.AdminNavbarData
 	DB            *gorm.DB
 }
 
 type userTemplateData struct {
-	Navbar      template.NavbarData
-	AdminNavbar template.AdminNavbarData
-	User        models.User
+	Navbar template.NavbarData
+	User   models.User
 
 	UploadLimit      models.UploadLimit
 	UploadLimitHuman struct {
@@ -176,7 +174,6 @@ func (h *userHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Re
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
-		AdminNavbar: h.AdminNavbar,
 	}
 
 	user, err := h.GetIntendedUser(r)

--- a/pkg/http/admin/userlist.go
+++ b/pkg/http/admin/userlist.go
@@ -10,13 +10,11 @@ import (
 
 type userlistHandler struct {
 	StaticHandler http.Handler
-	AdminNavbar   template.AdminNavbarData
 	DB            *gorm.DB
 }
 
 type userlistTemplateData struct {
-	Navbar      template.NavbarData
-	AdminNavbar template.AdminNavbarData
+	Navbar template.NavbarData
 
 	Users []*models.User
 }
@@ -26,7 +24,6 @@ func (h *userlistHandler) Serve(user *models.User, w http.ResponseWriter, r *htt
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
-		AdminNavbar: h.AdminNavbar,
 	}
 
 	tx := h.DB.Find(&data.Users)

--- a/pkg/http/apps.go
+++ b/pkg/http/apps.go
@@ -17,6 +17,7 @@ type appsHandler struct {
 type appTemplateData struct {
 	Navbar      template.NavbarData
 	App         string
+	Path        string
 	Permissions string
 }
 
@@ -30,16 +31,25 @@ func (h *appsHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// internal rewrite to the app page
-	r.URL.Path = "/app.gohtml"
-
-	ctx := template.AttachTemplateData(r.Context(), appTemplateData{
+	data := appTemplateData{
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
 		App:         appname,
 		Permissions: app.IFramePermissions(),
-	})
+	}
+
+	if len(split) > 1 {
+		// we temporarly set the path of our url to the end path that needs to go to the iframe
+		// this is purely done so we preserve any queries and fragments
+		r.URL.Path = split[1]
+		data.Path = r.URL.String()
+	}
+
+	// internal rewrite to the app page
+	r.URL.Path = "/app.gohtml"
+
+	ctx := template.AttachTemplateData(r.Context(), data)
 
 	h.StaticHandler.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/pkg/http/apps.go
+++ b/pkg/http/apps.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/http/template"
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+)
+
+type appsHandler struct {
+	StaticHandler http.Handler
+}
+
+type appTemplateData struct {
+	Navbar template.NavbarData
+	App    string
+}
+
+func (h *appsHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
+	split := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/apps/"), "/", 2)
+	appname := split[0]
+
+	// internal rewrite to the app page
+	r.URL.Path = "/app.gohtml"
+
+	ctx := template.AttachTemplateData(r.Context(), appTemplateData{
+		Navbar: template.NavbarData{
+			Admin: user.Admin,
+		},
+		App: appname,
+	})
+
+	h.StaticHandler.ServeHTTP(w, r.WithContext(ctx))
+}

--- a/pkg/http/apps.go
+++ b/pkg/http/apps.go
@@ -4,22 +4,31 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/leicht-cloud/leicht-cloud/pkg/app"
 	"github.com/leicht-cloud/leicht-cloud/pkg/http/template"
 	"github.com/leicht-cloud/leicht-cloud/pkg/models"
 )
 
 type appsHandler struct {
+	Apps          *app.Manager
 	StaticHandler http.Handler
 }
 
 type appTemplateData struct {
-	Navbar template.NavbarData
-	App    string
+	Navbar      template.NavbarData
+	App         string
+	Permissions string
 }
 
 func (h *appsHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Request) {
 	split := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/apps/"), "/", 2)
 	appname := split[0]
+
+	app, err := h.Apps.GetApp(appname)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
 
 	// internal rewrite to the app page
 	r.URL.Path = "/app.gohtml"
@@ -28,7 +37,8 @@ func (h *appsHandler) Serve(user *models.User, w http.ResponseWriter, r *http.Re
 		Navbar: template.NavbarData{
 			Admin: user.Admin,
 		},
-		App: appname,
+		App:         appname,
+		Permissions: app.IFramePermissions(),
 	})
 
 	h.StaticHandler.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/http/assets/admin.gohtml
+++ b/pkg/http/assets/admin.gohtml
@@ -25,7 +25,7 @@
 <body>
     <div class="container wrapper">
 
-        {{ adminnavbar .AdminNavbar }}
+        {{ adminnavbar . }}
 
         <div id="content">
         </div>

--- a/pkg/http/assets/admin.pluginview.gohtml
+++ b/pkg/http/assets/admin.pluginview.gohtml
@@ -25,7 +25,7 @@
 <body>
     <div class="container wrapper">
 
-        {{ adminnavbar .AdminNavbar }}
+        {{ adminnavbar . }}
 
         <div id="content">
             <h1 class="h2">{{ .Name }}</h1>

--- a/pkg/http/assets/admin.user.gohtml
+++ b/pkg/http/assets/admin.user.gohtml
@@ -25,7 +25,7 @@
 <body>
   <div class="container wrapper">
 
-    {{ adminnavbar .AdminNavbar }}
+    {{ adminnavbar . }}
 
     <div id="content">
       <h1 class="h2">{{ .User.Email }}</h1>

--- a/pkg/http/assets/admin.userlist.gohtml
+++ b/pkg/http/assets/admin.userlist.gohtml
@@ -25,7 +25,7 @@
 <body>
   <div class="container wrapper">
 
-    {{ adminnavbar .AdminNavbar }}
+    {{ adminnavbar . }}
 
     <div id="content">
       <h1 class="h2">Users</h1>

--- a/pkg/http/assets/app.gohtml
+++ b/pkg/http/assets/app.gohtml
@@ -22,7 +22,7 @@
 
 <body>
     <div style="height:90%" class="container wrapper">
-        <iframe src="/apps/embed/{{ .App }}/" height="100%" width="100%" sandbox="allow-same-origin {{ .Permissions }}">
+        <iframe src="/apps/embed/{{ .App }}/{{ .Path }}" height="100%" width="100%" sandbox="allow-same-origin {{ .Permissions }}">
         </iframe>
     </div>
 </body>

--- a/pkg/http/assets/app.gohtml
+++ b/pkg/http/assets/app.gohtml
@@ -22,7 +22,7 @@
 
 <body>
     <div style="height:90%" class="container wrapper">
-        <iframe src="/apps/embed/{{ .App }}/{{ .Path }}" height="100%" width="100%" sandbox="allow-same-origin {{ .Permissions }}">
+        <iframe src="/apps/embed/{{ .App }}/{{ .Path }}" height="100%" width="100%" sandbox="{{ .Permissions }}">
         </iframe>
     </div>
 </body>

--- a/pkg/http/assets/app.gohtml
+++ b/pkg/http/assets/app.gohtml
@@ -21,8 +21,8 @@
 </head>
 
 <body>
-    <div class="container wrapper">
-        <iframe src="/apps/embed/{{ .App }}" sandbox="{{ .Permissions }}">
+    <div style="height:90%" class="container wrapper">
+        <iframe src="/apps/embed/{{ .App }}/" height="100%" width="100%" sandbox="allow-same-origin {{ .Permissions }}">
         </iframe>
     </div>
 </body>

--- a/pkg/http/assets/app.gohtml
+++ b/pkg/http/assets/app.gohtml
@@ -22,7 +22,7 @@
 
 <body>
     <div class="container wrapper">
-        <iframe src="/apps/embed/{{ .App }}">
+        <iframe src="/apps/embed/{{ .App }}" sandbox="{{ .Permissions }}">
         </iframe>
     </div>
 </body>

--- a/pkg/http/assets/app.gohtml
+++ b/pkg/http/assets/app.gohtml
@@ -1,0 +1,30 @@
+<html>
+
+<head>
+    <link href="/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="/js/lib/bootstrap.bundle.min.js"></script>
+    <script src="/js/lib/jquery.min.js"></script>
+
+    {{ navbar .Navbar }}
+
+    <style>
+        .wrapper {
+            display: flex;
+            align-items: stretch;
+        }
+
+        #sidebar {
+            min-width: 250px;
+            max-width: 250px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container wrapper">
+        <iframe src="/apps/embed/{{ .App }}">
+        </iframe>
+    </div>
+</body>
+
+</html>

--- a/pkg/http/assets/folder.gohtml
+++ b/pkg/http/assets/folder.gohtml
@@ -153,6 +153,13 @@
     <div class="list-group list-group-flush container-fluid vh-100">
       <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="offcanvasRightLabel">Offcanvas</h5>
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Open
+          </button>
+          <ul class="dropdown-menu" id="fileinfoOpeners">
+          </ul>
+        </div>
         <a id="offcanvasDownloadLink">
           <!-- https://icons.getbootstrap.com/icons/download/ -->
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download"

--- a/pkg/http/assets/includes/navbar.admin.gohtml
+++ b/pkg/http/assets/includes/navbar.admin.gohtml
@@ -6,11 +6,11 @@
     <a class="list-group-item d-flex justify-content-between align-items-center collapsed" data-bs-toggle="collapse"
       data-bs-target="#plugins-collapse" aria-expanded="true">
       Plugins
-      <span class="badge bg-primary rounded-pill">{{ len .Plugins }}</span>
+      <span class="badge bg-primary rounded-pill">{{ len plugins }}</span>
     </a>
     <div class="collapse show" id="plugins-collapse">
       <ul class="list-group-item fw-normal pb-1 small">
-        {{ range $i, $plugin := .Plugins }}
+        {{ range $i, $plugin := plugins }}
         <li><a href="/admin/plugin?name={{ $plugin }}" class="link-dark rounded">{{ $plugin }}</a></li>
         {{ end }}
       </ul>

--- a/pkg/http/assets/includes/navbar.gohtml
+++ b/pkg/http/assets/includes/navbar.gohtml
@@ -11,6 +11,16 @@
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="/">Home</a>
         </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Apps
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+            {{ range $i, $app := apps }}
+            <li><a class="dropdown-item" href="/apps/{{ $app }}">{{ $app }}</a></li>
+            {{ end }}
+          </ul>
+        </li>
         {{ if .Admin }}
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="/admin">Admin</a>

--- a/pkg/http/assets/js/folder.js
+++ b/pkg/http/assets/js/folder.js
@@ -51,7 +51,7 @@ function fileInfo(file) {
 
     var addFileOpener = function(appname, mime) {
         var element = $(
-            '<li><a class="dropdown-item" href="/apps/' + appname + '/open?mime=' + mime + '&file=' + file + '">' + appname + '</a></li>'
+            '<li><a class="dropdown-item" href="/apps/' + appname + '/?action=open&mime=' + mime + '&file=' + file + '">' + appname + '</a></li>'
         );
 
         var parent = $('#fileinfoOpeners');

--- a/pkg/http/assets/js/folder.js
+++ b/pkg/http/assets/js/folder.js
@@ -29,7 +29,7 @@ function fileInfo(file) {
     var offcanvas = new bootstrap.Offcanvas($('#offcanvasRight'));
     offcanvas.show();
 
-    var add = function (title, text, name) {
+    var addFileinfo = function (title, text, name) {
         var element = $(
                 '<div class="list-group-item justify-content-between text-break" style="font-family:monospace;"></div>')
             .text(text);
@@ -49,13 +49,26 @@ function fileInfo(file) {
         body.append(element);
     };
 
+    var addFileOpener = function(appname, mime) {
+        var element = $(
+            '<li><a class="dropdown-item" href="/apps/' + appname + '/open?mime=' + mime + '&file=' + file + '">' + appname + '</a></li>'
+        );
+
+        var parent = $('#fileinfoOpeners');
+        parent.append(element);
+    };
+
     var socket = new WebSocket("ws://" + document.location.host + "/webapi/fileinfo?filename=" + file);
     socket.onmessage = function (event) {
         var json = JSON.parse(event.data);
-        if (json.title != "") {
-            add(json.title, json.human, json.name);
+        if (json.apps !== undefined && json.mime !== undefined) {
+            for (let appname in json.apps) {
+                addFileOpener(appname, json.mime);
+            }
+        } else if (json.title != "") {
+            addFileinfo(json.title, json.human, json.name);
         } else {
-            add(json.name, json.human, json.name);
+            addFileinfo(json.name, json.human, json.name);
         }
     };
 };

--- a/pkg/http/init.go
+++ b/pkg/http/init.go
@@ -35,7 +35,8 @@ func InitHttpServer(
 	mux.Handle("/", &rootHandler{DB: db, StaticHandler: templateHandler})
 	mux.Handle("/login", &loginHandler{DB: db, Auth: authProvider, StaticHandler: templateHandler})
 	mux.Handle("/signup", &signupHandler{Assets: assets, DB: db, Storage: storage})
-	mux.Handle("/apps/", auth.AuthHandler(apps))
+	mux.Handle("/apps/embed/", auth.AuthHandler(apps))
+	mux.Handle("/apps/", auth.AuthHandler(&appsHandler{StaticHandler: templateHandler}))
 	webapi.Init(mux, db, storage, fileinfo)
 	admin.Init(mux, authProvider, templateHandler, pluginManager, db)
 

--- a/pkg/http/init.go
+++ b/pkg/http/init.go
@@ -22,7 +22,7 @@ func InitHttpServer(
 	apps *app.Manager,
 	fileinfo *fileinfo.Manager,
 ) (*http.Server, error) {
-	assets, err := initStatic()
+	assets, err := InitStatic()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/http/init.go
+++ b/pkg/http/init.go
@@ -36,7 +36,7 @@ func InitHttpServer(
 	mux.Handle("/login", &loginHandler{DB: db, Auth: authProvider, StaticHandler: templateHandler})
 	mux.Handle("/signup", &signupHandler{Assets: assets, DB: db, Storage: storage})
 	mux.Handle("/apps/embed/", auth.AuthHandler(apps))
-	mux.Handle("/apps/", auth.AuthHandler(&appsHandler{StaticHandler: templateHandler}))
+	mux.Handle("/apps/", auth.AuthHandler(&appsHandler{Apps: apps, StaticHandler: templateHandler}))
 	webapi.Init(mux, db, storage, fileinfo)
 	admin.Init(mux, authProvider, templateHandler, pluginManager, db)
 

--- a/pkg/http/init.go
+++ b/pkg/http/init.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 
+	"github.com/leicht-cloud/leicht-cloud/pkg/app"
 	"github.com/leicht-cloud/leicht-cloud/pkg/auth"
 	"github.com/leicht-cloud/leicht-cloud/pkg/fileinfo"
 	"github.com/leicht-cloud/leicht-cloud/pkg/http/admin"
@@ -18,6 +19,7 @@ func InitHttpServer(
 	authProvider *auth.Provider,
 	storage storage.StorageProvider,
 	pluginManager *plugin.Manager,
+	apps *app.Manager,
 	fileinfo *fileinfo.Manager,
 ) (*http.Server, error) {
 	assets, err := initStatic()
@@ -33,6 +35,7 @@ func InitHttpServer(
 	mux.Handle("/", &rootHandler{DB: db, StaticHandler: templateHandler})
 	mux.Handle("/login", &loginHandler{DB: db, Auth: authProvider, StaticHandler: templateHandler})
 	mux.Handle("/signup", &signupHandler{Assets: assets, DB: db, Storage: storage})
+	mux.Handle("/apps/", auth.AuthHandler(apps))
 	webapi.Init(mux, db, storage, fileinfo)
 	admin.Init(mux, authProvider, templateHandler, pluginManager, db)
 

--- a/pkg/http/init.go
+++ b/pkg/http/init.go
@@ -37,7 +37,7 @@ func InitHttpServer(
 	mux.Handle("/signup", &signupHandler{Assets: assets, DB: db, Storage: storage})
 	mux.Handle("/apps/embed/", auth.AuthHandler(apps))
 	mux.Handle("/apps/", auth.AuthHandler(&appsHandler{Apps: apps, StaticHandler: templateHandler}))
-	webapi.Init(mux, db, storage, fileinfo)
+	webapi.Init(mux, db, storage, fileinfo, apps)
 	admin.Init(mux, authProvider, templateHandler, pluginManager, db)
 
 	out := &http.Server{

--- a/pkg/http/init.go
+++ b/pkg/http/init.go
@@ -26,7 +26,7 @@ func InitHttpServer(
 	if err != nil {
 		return nil, err
 	}
-	templateHandler, err := template.NewHandler(assets)
+	templateHandler, err := template.NewHandler(assets, apps.Apps(), pluginManager.Plugins())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/http/static.go
+++ b/pkg/http/static.go
@@ -10,7 +10,7 @@ import (
 //go:embed assets
 var assets embed.FS
 
-func initStatic() (fs.FS, error) {
+func InitStatic() (fs.FS, error) {
 	embedded, err := fs.Sub(assets, "assets")
 	if err != nil {
 		return nil, err

--- a/pkg/http/static_html.go
+++ b/pkg/http/static_html.go
@@ -7,6 +7,6 @@ import (
 	"os"
 )
 
-func initStatic() (fs.FS, error) {
+func InitStatic() (fs.FS, error) {
 	return os.DirFS("assets"), nil
 }

--- a/pkg/http/template/handler normal.go
+++ b/pkg/http/template/handler normal.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 )
 
-func NewHandler(assets fs.FS) (out *TemplateHandler, err error) {
+func NewHandler(assets fs.FS, apps, plugins []string) (out *TemplateHandler, err error) {
 	// we first create an empty template so we can first attach the funcmap
 	tmpl := template.New("")
 
-	funcMap, err := createFuncMap(assets)
+	funcMap, err := createFuncMap(assets, apps, plugins)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +29,8 @@ func NewHandler(assets fs.FS) (out *TemplateHandler, err error) {
 		assets:      assets,
 		template:    tmpl,
 		fileHandler: http.FileServer(http.FS(assets)),
+		apps:        apps,
+		plugins:     plugins,
 	}, nil
 }
 
@@ -43,18 +45,25 @@ func (t *TemplateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func tmplFunc(assets fs.FS, name string) func(data interface{}) (template.HTML, error) {
-	tmpl, err := template.ParseFS(assets, name)
+func tmplFunc(assets fs.FS, name string, funcMap template.FuncMap) func(data interface{}) (template.HTML, error) {
+	tmpl := template.New("")
+
+	// we attach the funcMap
+	tmpl = tmpl.Funcs(funcMap)
+
+	tmpl, err := tmpl.ParseFS(assets, name)
 	if err != nil {
 		panic(err)
 	}
-	// we make sure there was just 1 template with this name
-	if len(tmpl.Templates()) != 1 {
+
+	// we should have 2 templates now, the first empty one that we created just so we could attach a function map
+	// and the second one that we actually want..
+	if len(tmpl.Templates()) != 2 {
 		panic(fmt.Errorf("Found an odd amount of templates with the name %s in assets", name))
 	}
 
 	// then we change the main template to the one we were out for
-	tmpl = tmpl.Templates()[0]
+	tmpl = tmpl.Templates()[1]
 
 	// then we return a function with this specific template, resulting in it only being parsed once
 	// TODO: Ideally we'd be writing directly to the main template somehow, rather than first writing into a string/buffer

--- a/pkg/http/template/navbar.go
+++ b/pkg/http/template/navbar.go
@@ -3,7 +3,3 @@ package template
 type NavbarData struct {
 	Admin bool
 }
-
-type AdminNavbarData struct {
-	Plugins []string
-}

--- a/pkg/http/webapi/init.go
+++ b/pkg/http/webapi/init.go
@@ -3,16 +3,17 @@ package webapi
 import (
 	"net/http"
 
+	"github.com/leicht-cloud/leicht-cloud/pkg/app"
 	"github.com/leicht-cloud/leicht-cloud/pkg/fileinfo"
 	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
 	"gorm.io/gorm"
 )
 
-func Init(mux *http.ServeMux, db *gorm.DB, storage storage.StorageProvider, fileinfo *fileinfo.Manager) {
+func Init(mux *http.ServeMux, db *gorm.DB, storage storage.StorageProvider, fileinfo *fileinfo.Manager, apps *app.Manager) {
 	mux.Handle("/webapi/upload", newUploadHandler(db, storage))
 	mux.Handle("/webapi/download", newDownloadHandler(db, storage))
 	mux.Handle("/webapi/list", newListHandler(storage))
-	mux.Handle("/webapi/fileinfo", newFileInfoHandler(storage, fileinfo))
+	mux.Handle("/webapi/fileinfo", newFileInfoHandler(storage, fileinfo, apps))
 	mux.Handle("/webapi/mkdir", newMkdirHandler(storage))
 	mux.Handle("/webapi/delete", newDeleteHandler(storage))
 }

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -133,9 +133,12 @@ func (m *Manager) prepareDirectory(name, typ string) (*Manifest, error) {
 					return nil, err
 				}
 				if header.Name == "plugin.manifest.yml" {
-					manifest, err = parseManifest(tr, typ)
+					manifest, err = parseManifest(tr)
 					if err != nil {
 						return nil, err
+					}
+					if manifest.Type != typ {
+						return nil, fmt.Errorf("Incorrect type, got: %s, expected: %s", manifest.Type, typ)
 					}
 				} else if header.Name == wantedExecutable {
 					dst, err := os.OpenFile(pluginFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, plugin_permissions)
@@ -165,9 +168,12 @@ func (m *Manager) prepareDirectory(name, typ string) (*Manifest, error) {
 		dir := filepath.Join(path, name)
 		fi, err := os.Stat(dir)
 		if err == nil && fi.IsDir() {
-			manifest, err := ParseManifestFromFile(filepath.Join(path, name), typ)
+			manifest, err := ParseManifestFromFile(filepath.Join(path, name))
 			if err != nil {
 				return nil, err
+			}
+			if manifest.Type != typ {
+				return nil, fmt.Errorf("Incorrect type, got: %s, expected: %s", manifest.Type, typ)
 			}
 			src, err := os.Open(filepath.Join(dir, name))
 			if err != nil {

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -22,7 +22,12 @@ type Manifest struct {
 }
 
 type Permissions struct {
-	Network bool `yaml:"network"`
+	Container struct {
+		Network bool `yaml:"network"`
+	} `yaml:"container"`
+	App struct {
+		Javascript bool `yaml:"javascript"`
+	} `yaml:"app"`
 }
 
 // path should be the path to the plugin, not directly to the manifest

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -38,16 +38,16 @@ type Permissions struct {
 }
 
 // path should be the path to the plugin, not directly to the manifest
-func ParseManifestFromFile(path, typ string) (*Manifest, error) {
+func ParseManifestFromFile(path string) (*Manifest, error) {
 	f, err := os.Open(filepath.Join(path, "plugin.manifest.yml"))
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return parseManifest(f, typ)
+	return parseManifest(f)
 }
 
-func parseManifest(r io.Reader, typ string) (*Manifest, error) {
+func parseManifest(r io.Reader) (*Manifest, error) {
 	out := &Manifest{}
 	err := yaml.NewDecoder(r).Decode(out)
 	if err != nil {
@@ -55,9 +55,6 @@ func parseManifest(r io.Reader, typ string) (*Manifest, error) {
 	}
 	if out.Name == "" {
 		return nil, ErrNoName
-	}
-	if typ != "" && out.Type != typ {
-		return nil, fmt.Errorf("Unwanted type: %s", out.Type)
 	}
 	return out, nil
 }

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -86,8 +86,7 @@ func (m *Manifest) Warnings() <-chan Warning {
 		if len(m.Permissions.App.FileOpener) > 0 {
 			if !m.Permissions.App.Storage.Enabled {
 				ch <- Warning{error: fmt.Errorf("Manifest has file openers specified, but storage library is disabled.")}
-			}
-			if !m.Permissions.App.Storage.WholeStore {
+			} else if !m.Permissions.App.Storage.WholeStore {
 				ch <- Warning{error: fmt.Errorf("Manifest has file openers specified, but will only have access to a subset. Which is currently not supported.")}
 			}
 		}

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -27,6 +27,7 @@ type Permissions struct {
 	} `yaml:"container"`
 	App struct {
 		Javascript bool `yaml:"javascript"`
+		Forms      bool `yaml:"forms"`
 		Storage    struct {
 			Enabled    bool `yaml:"enabled"`
 			ReadWrite  bool `yaml:"readwrite"`

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -32,6 +32,7 @@ type Permissions struct {
 			ReadWrite  bool `yaml:"readwrite"`
 			WholeStore bool `yaml:"wholestore"`
 		} `yaml:"storage"`
+		FileOpener map[string]string `yaml:"file_opener"`
 	} `yaml:"app"`
 }
 

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -27,6 +27,11 @@ type Permissions struct {
 	} `yaml:"container"`
 	App struct {
 		Javascript bool `yaml:"javascript"`
+		Storage    struct {
+			Enabled    bool `yaml:"enabled"`
+			ReadWrite  bool `yaml:"readwrite"`
+			WholeStore bool `yaml:"wholestore"`
+		} `yaml:"storage"`
 	} `yaml:"app"`
 }
 

--- a/pkg/plugin/manifest_test.go
+++ b/pkg/plugin/manifest_test.go
@@ -1,0 +1,87 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestWarning(t *testing.T) {
+	units := []struct {
+		name             string
+		input            string
+		expectedWarnings []Warning
+	}{
+		{
+			name: "invalid type",
+			input: `
+name: INVALID
+type: INVALID
+`,
+			expectedWarnings: []Warning{
+				{error: fmt.Errorf("INVALID is not a valid type"), Fatal: true},
+			},
+		},
+		{
+			name: "fileopener, with storage disabled",
+			input: `
+name: test
+type: app
+permissions:
+  app:
+    storage:
+      enabled: false
+    file_opener:
+      text/*: /file?file=%file%
+`,
+			expectedWarnings: []Warning{
+				{error: fmt.Errorf("Manifest has file openers specified, but storage library is disabled.")},
+			},
+		},
+		{
+			name: "fileopener, no wholestore",
+			input: `
+name: test
+type: app
+permissions:
+  app:
+    storage:
+      enabled: true
+      wholestore: false
+    file_opener:
+      text/*: /file?file=%file%
+`,
+			expectedWarnings: []Warning{
+				{error: fmt.Errorf("Manifest has file openers specified, but will only have access to a subset. Which is currently not supported.")},
+			},
+		},
+	}
+
+	for _, unit := range units {
+		t.Run(unit.name, func(t *testing.T) {
+			manifest, err := parseManifest(strings.NewReader(unit.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ch := manifest.Warnings()
+			expected := unit.expectedWarnings
+
+			for warning := range ch {
+				if len(expected) == 0 {
+					t.Errorf("Unexpected warning: %s", warning)
+				} else {
+					w := expected[0]
+					expected = expected[1:]
+
+					assert.Equal(t, w.Error(), warning.Error())
+					assert.Equal(t, w.Fatal, warning.Fatal)
+				}
+			}
+
+			assert.Empty(t, expected, "Didn't see all expected warnings")
+		})
+	}
+}

--- a/pkg/plugin/namespace_runner_linux.go
+++ b/pkg/plugin/namespace_runner_linux.go
@@ -84,7 +84,7 @@ func (n *namespaceFactory) Create(opts *RunOptions) (Runner, error) {
 
 	// in the case of no network permission, we still go into a network namespace
 	// with the difference that we never set up the network
-	if opts.Manifest.Permissions.Network {
+	if opts.Manifest.Permissions.Container.Network {
 		out.cmd.Env = append(out.cmd.Env, fmt.Sprintf("NETWORK=%s", n.NetworkMode))
 
 		netFactory, ok := network_modes[n.NetworkMode]

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -19,11 +19,13 @@ type PluginInterface interface {
 	HttpClient() *http.Client
 	Stdout() []byte
 	Close() error
+	Manifest() *Manifest
 }
 
 type plugin struct {
-	name    string
-	workDir string
+	name     string
+	manifest *Manifest
+	workDir  string
 
 	httpClient http.Client
 
@@ -33,9 +35,10 @@ type plugin struct {
 
 func (m *Manager) newPluginInstance(manifest *Manifest, cfg *Config, name string) (*plugin, error) {
 	p := &plugin{
-		name:    name,
-		workDir: filepath.Join(cfg.WorkDir, name),
-		stdout:  newStdout(),
+		name:     name,
+		workDir:  filepath.Join(cfg.WorkDir, name),
+		stdout:   newStdout(),
+		manifest: manifest,
 	}
 	// we initialize httpClient seperate, as it needs an initialized plugin already for the httpSocketFile call
 	p.httpClient = http.Client{
@@ -130,4 +133,8 @@ func (p *plugin) GrpcConn() (*grpc.ClientConn, error) {
 
 func (p *plugin) HttpClient() *http.Client {
 	return &p.httpClient
+}
+
+func (p *plugin) Manifest() *Manifest {
+	return p.manifest
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -45,6 +45,10 @@ func (m *Manager) newPluginInstance(manifest *Manifest, cfg *Config, name string
 	}
 	// we initialize httpClient seperate, as it needs an initialized plugin already for the httpSocketFile call
 	p.httpClient = http.Client{
+		// as we intend to act as a proxy, we are not actually handling redirects at all
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return net.Dial("unix", p.httpSocketFile())

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -17,7 +18,8 @@ import (
 type PluginInterface interface {
 	GrpcConn() (*grpc.ClientConn, error)
 	HttpClient() *http.Client
-	Stdout() []byte
+	StdoutDump() []byte
+	Stdout() io.ReadCloser
 	Close() error
 	Manifest() *Manifest
 	WorkDir() string
@@ -80,8 +82,12 @@ func (p *plugin) Close() error {
 	return p.runner.Close()
 }
 
-func (p *plugin) Stdout() []byte {
+func (p *plugin) StdoutDump() []byte {
 	return p.stdout.Bytes()
+}
+
+func (p *plugin) Stdout() io.ReadCloser {
+	return p.stdout.Reader()
 }
 
 func (p *plugin) Describe(chan<- *prometheus.Desc) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -20,6 +20,7 @@ type PluginInterface interface {
 	Stdout() []byte
 	Close() error
 	Manifest() *Manifest
+	WorkDir() string
 }
 
 type plugin struct {
@@ -137,4 +138,8 @@ func (p *plugin) HttpClient() *http.Client {
 
 func (p *plugin) Manifest() *Manifest {
 	return p.manifest
+}
+
+func (p *plugin) WorkDir() string {
+	return p.workDir
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -16,6 +16,7 @@ import (
 
 type PluginInterface interface {
 	GrpcConn() (*grpc.ClientConn, error)
+	HttpClient() *http.Client
 	Stdout() []byte
 	Close() error
 }
@@ -125,4 +126,8 @@ func (p *plugin) GrpcConn() (*grpc.ClientConn, error) {
 			return dialer.DialContext(ctx, "unix", addr)
 		}),
 	)
+}
+
+func (p *plugin) HttpClient() *http.Client {
+	return &p.httpClient
 }

--- a/pkg/plugin/stdout_test.go
+++ b/pkg/plugin/stdout_test.go
@@ -66,3 +66,19 @@ func TestRemoveChannel(t *testing.T) {
 	assert.Len(t, stdout.channels, 99)
 	assert.NotContains(t, stdout.channels, ch)
 }
+
+func TestReader(t *testing.T) {
+	stdout := newStdout()
+
+	stdout.Write(testText)
+	reader := stdout.Reader()
+
+	buf := make([]byte, 1024*4)
+	n, err := reader.Read(buf)
+	assert.NoError(t, err)
+	assert.Len(t, testText, n)
+
+	stdout.Write(testText)
+	assert.NoError(t, err)
+	assert.Len(t, testText, n)
+}

--- a/pkg/storage/firewall/firewall.go
+++ b/pkg/storage/firewall/firewall.go
@@ -1,0 +1,75 @@
+package firewall
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage/utils"
+)
+
+var ErrReadOnly = errors.New("Readonly storage")
+
+type FirewallStorageProvider struct {
+	proxy     storage.StorageProvider
+	directory string
+}
+
+func Firewall(provider storage.StorageProvider, directory string) storage.StorageProvider {
+	return &FirewallStorageProvider{proxy: provider, directory: directory}
+}
+
+func (f *FirewallStorageProvider) InitUser(ctx context.Context, user *models.User) error {
+	return f.proxy.InitUser(ctx, user)
+}
+
+func (f *FirewallStorageProvider) Mkdir(ctx context.Context, user *models.User, path string) error {
+	err := utils.ValidatePath(path)
+	if err != nil {
+		return err
+	}
+
+	return f.proxy.Mkdir(ctx, user, filepath.Join(f.directory, path))
+}
+
+func (f *FirewallStorageProvider) Move(ctx context.Context, user *models.User, src string, dst string) error {
+	err := utils.ValidatePath(src)
+	if err != nil {
+		return err
+	}
+	err = utils.ValidatePath(dst)
+	if err != nil {
+		return err
+	}
+
+	return f.proxy.Move(ctx, user, filepath.Join(f.directory, src), filepath.Join(f.directory, dst))
+}
+
+func (f *FirewallStorageProvider) ListDirectory(ctx context.Context, user *models.User, path string) (<-chan storage.FileInfo, error) {
+	err := utils.ValidatePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.proxy.ListDirectory(ctx, user, filepath.Join(f.directory, path))
+}
+
+func (f *FirewallStorageProvider) File(ctx context.Context, user *models.User, fullpath string) (storage.File, error) {
+	err := utils.ValidatePath(fullpath)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.proxy.File(ctx, user, filepath.Join(f.directory, fullpath))
+}
+
+func (f *FirewallStorageProvider) Delete(ctx context.Context, user *models.User, fullpath string) error {
+	err := utils.ValidatePath(fullpath)
+	if err != nil {
+		return err
+	}
+
+	return f.proxy.Delete(ctx, user, filepath.Join(f.directory, fullpath))
+}

--- a/pkg/storage/firewall/firewall_test.go
+++ b/pkg/storage/firewall/firewall_test.go
@@ -1,0 +1,45 @@
+package firewall
+
+import (
+	"context"
+	"testing"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage"
+	"github.com/leicht-cloud/leicht-cloud/pkg/storage/builtin/local"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFirewallStorage(t *testing.T) {
+	contents := []byte("This is just a simple test.")
+	user := &models.User{
+		ID:    1337,
+		Email: "test@test.com",
+	}
+
+	store := local.NewStorageProvider(t.TempDir())
+	provider := Firewall(store, "test/directory")
+
+	storage.TestStorageProvider(provider, t)
+
+	if !t.Run("WriteInFirewall", func(t *testing.T) {
+		file, err := provider.File(context.Background(), user, "test.txt")
+		if assert.Nil(t, err) {
+			_, err = file.Write(contents)
+			assert.Nil(t, err)
+		}
+	}) {
+		return
+	}
+
+	t.Run("ReadOutsideFirewall", func(t *testing.T) {
+		file, err := store.File(context.Background(), user, "test/directory/test.txt")
+		if assert.Nil(t, err) {
+			buf := make([]byte, 1024)
+			n, err := file.Read(buf)
+			assert.Nil(t, err)
+
+			assert.Equal(t, contents, buf[:n])
+		}
+	})
+}

--- a/pkg/storage/readonly.go
+++ b/pkg/storage/readonly.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"github.com/leicht-cloud/leicht-cloud/pkg/models"
+)
+
+var ErrReadOnly = errors.New("Readonly storage")
+
+type ReadonlyStorage struct {
+	proxy StorageProvider
+}
+
+func ReadOnly(provider StorageProvider) StorageProvider {
+	return &ReadonlyStorage{proxy: provider}
+}
+
+func (r *ReadonlyStorage) InitUser(ctx context.Context, user *models.User) error {
+	return r.proxy.InitUser(ctx, user)
+}
+
+func (r *ReadonlyStorage) Mkdir(ctx context.Context, user *models.User, path string) error {
+	return ErrReadOnly
+}
+
+func (r *ReadonlyStorage) Move(ctx context.Context, user *models.User, src string, dst string) error {
+	return ErrReadOnly
+}
+
+func (r *ReadonlyStorage) ListDirectory(ctx context.Context, user *models.User, path string) (<-chan FileInfo, error) {
+	return r.proxy.ListDirectory(ctx, user, path)
+}
+
+func (r *ReadonlyStorage) File(ctx context.Context, user *models.User, fullpath string) (File, error) {
+	file, err := r.proxy.File(ctx, user, fullpath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &readOnlyFile{proxy: file}, nil
+}
+
+func (r *ReadonlyStorage) Delete(ctx context.Context, user *models.User, fullpath string) error {
+	return ErrReadOnly
+}
+
+type readOnlyFile struct {
+	proxy File
+}
+
+func (r *readOnlyFile) Read(p []byte) (n int, err error) {
+	return r.proxy.Read(p)
+}
+
+func (r *readOnlyFile) Close() error {
+	return r.proxy.Close()
+}
+
+func (r *readOnlyFile) Write(p []byte) (n int, err error) {
+	return -1, ErrReadOnly
+}

--- a/pkg/storage/utils/config.go
+++ b/pkg/storage/utils/config.go
@@ -51,7 +51,7 @@ func fromConfig(cfg *Config, pManager *plugin.Manager) (storage.StorageProvider,
 
 		store, err := storagePlugin.NewGrpcStorage(conn, cfg.Extra)
 		if err != nil {
-			stdout := plugin.Stdout()
+			stdout := plugin.StdoutDump()
 			if len(stdout) > 0 {
 				logrus.Infof("-----STDOUT FOR PLUGIN: %s-----", name)
 				_, _ = io.Copy(os.Stdout, bytes.NewReader(stdout))


### PR DESCRIPTION
This intends to implement initial and basic app support. An app would be it's own plugin running a http server with a frontend, which would be embedded in the main frontend through an iframe. It would also have access to the underlying datastore of the user, or a sub directory of it. As of right now only the frontend proxying into the main frontend is implemented.